### PR TITLE
JCLOUDS-534 Avoid runtime incompatibility introduced by Guava's closeQuietly.

### DIFF
--- a/core/src/main/java/org/jclouds/chef/handlers/ChefErrorHandler.java
+++ b/core/src/main/java/org/jclouds/chef/handlers/ChefErrorHandler.java
@@ -16,9 +16,7 @@
  */
 package org.jclouds.chef.handlers;
 
-import static com.google.common.base.Throwables.propagate;
-
-import java.io.IOException;
+import static org.jclouds.util.Closeables2.closeQuietly;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -32,8 +30,6 @@ import org.jclouds.http.HttpResponseException;
 import org.jclouds.logging.Logger;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ResourceNotFoundException;
-
-import com.google.common.io.Closeables;
 
 /**
  * This will parse and set an appropriate exception on the command object.
@@ -67,13 +63,7 @@ public class ChefErrorHandler implements HttpErrorHandler {
                break;
          }
       } finally {
-         if (response.getPayload() != null) {
-            try {
-               Closeables.close(response.getPayload().getInput(), true);
-            } catch (IOException e) {
-               throw propagate(e);
-            }
-         }
+         closeQuietly(response.getPayload());
          command.setException(exception);
       }
    }

--- a/core/src/test/java/org/jclouds/chef/internal/BaseChefApiLiveTest.java
+++ b/core/src/test/java/org/jclouds/chef/internal/BaseChefApiLiveTest.java
@@ -16,11 +16,11 @@
  */
 package org.jclouds.chef.internal;
 
-import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.isEmpty;
 import static com.google.common.hash.Hashing.md5;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.jclouds.util.Closeables2.closeQuietly;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -30,7 +30,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +64,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
-import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.primitives.Bytes;
 
@@ -531,12 +529,7 @@ public abstract class BaseChefApiLiveTest<A extends ChefApi> extends BaseChefLiv
          Client client = clientApi.getClient(identity);
          assertNotNull(client, "Client not found: " + identity);
       } finally {
-         try {
-            Closeables.close(clientApi, true);
-         } catch (IOException e) {
-            throw propagate(e);
-         }
+         closeQuietly(clientApi);
       }
    }
-
 }


### PR DESCRIPTION
This is only to apply towards 1.8.x as already sorted in jclouds/jclouds on master
